### PR TITLE
Add vertical wind interpolation in urban canyon

### DIFF
--- a/src/firebench/wind_interpolation/__init__.py
+++ b/src/firebench/wind_interpolation/__init__.py
@@ -3,3 +3,4 @@ from .wind_reduction_factor import (
     Baughman_20ft_wind_reduction_factor_unsheltered,
     Baughman_generalized_wind_reduction_factor_unsheltered,
 )
+from .vertical_urban import Masson_canyon

--- a/src/firebench/wind_interpolation/vertical_urban.py
+++ b/src/firebench/wind_interpolation/vertical_urban.py
@@ -54,7 +54,7 @@ def Masson_canyon(
     ----------
     Masson, V. (2000). A physically-based scheme for the urban energy budget in atmospheric models.
     Boundary-Layer Meteorology, 94, 357-397.
-    """ # pylint: disable=line-too-long
+    """  # pylint: disable=line-too-long
     h_b = get_value_by_category(building_height, fuel_cat)  # Building height [m]
     d_b = get_value_by_category(building_separation, fuel_cat)  # Building separation [m]
 

--- a/src/firebench/wind_interpolation/vertical_urban.py
+++ b/src/firebench/wind_interpolation/vertical_urban.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from ..tools import get_value_by_category
+
+
+def Masson_canyon(
+    wind_speed_atm: float,
+    input_wind_height: float,
+    building_height: float | list | np.ndarray,
+    building_separation: float | list | np.ndarray,
+    fuel_cat: int = 0,
+):
+    """
+    Compute the wind speed in an urban canyon using the Masson (2000) model.
+
+    This function estimates the wind speed in an urban canyon based on the atmospheric wind speed,
+    building height, and building separation distance. If the building height and separation distance
+    are provided as lists or NumPy arrays, the function selects the appropriate value based on the
+    specified `fuel_cat` index.
+
+    Parameters
+    ----------
+    wind_speed_atm : float
+        Wind speed above buildings [m/s].
+    input_wind_height : float
+        Height at which wind speed is given above buildings [m].
+    building_height : float, list, or np.ndarray
+        Building height [m]. If a list or array, `fuel_cat` is used to select the value.
+    building_separation : float, list, or np.ndarray
+        Average building separation distance [m]. If a list or array, `fuel_cat` is used to select the value.
+    fuel_cat : int, optional
+        Index for selecting values from list or array inputs. Default is 0.
+
+    Returns
+    -------
+    float
+        Estimated wind speed in the urban canyon [m/s].
+
+    Raises
+    ------
+    ValueError
+        If `fuel_cat` is out of range for the provided list or array inputs.
+
+    Notes
+    -----
+    **One-Based Indexing:**
+    `fuel_cat` uses one-based indexing to align with natural fuel category numbering
+    (i.e., the first fuel category is `fuel_cat=1`).
+
+    **Roughness Length Calculation:**
+    The roughness length (`z_0`) is estimated as 10% of the building height, with a minimum value of 5m.
+
+    References
+    ----------
+    Masson, V. (2000). A physically-based scheme for the urban energy budget in atmospheric models.
+    Boundary-Layer Meteorology, 94, 357-397.
+    """ # pylint: disable=line-too-long
+    h_b = get_value_by_category(building_height, fuel_cat)  # Building height [m]
+    d_b = get_value_by_category(building_separation, fuel_cat)  # Building separation [m]
+
+    z_0 = 0.1 * max(5, h_b)  # Roughness length estimation
+
+    return (
+        (2 / np.pi)
+        * np.exp(-0.25 * h_b / d_b)
+        * np.log(h_b / (3 * z_0))
+        / np.log((input_wind_height - 2 * h_b / 3) / z_0)
+        * np.abs(wind_speed_atm)
+    )

--- a/tests/regression/test_reg_wind_interpolation.py
+++ b/tests/regression/test_reg_wind_interpolation.py
@@ -46,3 +46,34 @@ def test_Baughman_generalized_wind_reduction_factor_unsheltered_regression(
         f"vegetation_height={vegetation_height}, is_source_wind_height_above_veg={is_source_wind_height_above_veg}: "
         f"expected {expected_wrf}, got {result}"
     )
+
+
+@pytest.mark.parametrize(
+    "wind_speed_atm, input_wind_height, building_height, building_separation, fuel_cat, expected_wind_canyon",
+    [
+        (10, 100, 20, 3, 2, 0.38410989518782196),
+        (10, 100, 2, 1, 1, 0.21018870345549612),
+        (10, 100, 30, 6, 3, 0.6688103823022014),
+        (10, 100, 50, 15, 4, 1.2859976393496242),
+    ],
+)
+def test_Masson_canyon_regression(
+    wind_speed_atm, input_wind_height, building_height, building_separation, fuel_cat, expected_wind_canyon
+):
+    # dummy building classification
+    building_height_cat = [2, 20, 30, 50]
+    building_separation_cat = [1, 3, 6, 15]
+
+    # Direct computation
+    wind_can = fwi.Masson_canyon(wind_speed_atm, input_wind_height, building_height, building_separation)
+    assert np.isclose(
+        wind_can, expected_wind_canyon, rtol=1e-5
+    ), f"Failed for direct computation, expected {expected_wind_canyon}, got {wind_can}"
+
+    # Computation using categorical classification
+    wind_can = fwi.Masson_canyon(
+        wind_speed_atm, input_wind_height, building_height_cat, building_separation_cat, fuel_cat=fuel_cat
+    )
+    assert np.isclose(
+        wind_can, expected_wind_canyon, rtol=1e-5
+    ), f"Failed for use of classification, expected {expected_wind_canyon}, got {wind_can}"

--- a/tests/regression/test_reg_wind_interpolation.py
+++ b/tests/regression/test_reg_wind_interpolation.py
@@ -26,13 +26,11 @@ def test_Baughman_20ft_wrf_unsheltered_regression(flame_height, vegetation_heigh
 @pytest.mark.parametrize(
     "input_wind_height, flame_height, vegetation_height, is_source_wind_height_above_veg, expected_wrf",
     [
-        (20.0, 6.0, 2.0, False, 0.5892891329244908),  # example value, replace with known expected output
-        (20.0, 6.0, 2.0, True, 0.5756265984603116),  # example value, replace with known expected output
-        (15.0, 5.0, 1.5, False, 0.6075278401473907),  # example value, replace with known expected output
-        (15.0, 5.0, 1.5, True, 0.5934424454061547),  # example value, replace with known expected output
-        (10.0, 4.0, 1.0, False, 0.64002283721826),  # example value, replace with known expected output
-        (10.0, 4.0, 1.0, True, 0.6251840533636174),  # example value, replace with known expected output
-        # Add more test cases as necessary
+        (20.0, 6.0, 2.0, False, 0.5892891329244908),
+        (15.0, 5.0, 1.5, False, 0.6075278401473907),
+        (15.0, 5.0, 1.5, True, 0.5934424454061547),
+        (10.0, 4.0, 1.0, False, 0.64002283721826),
+        (10.0, 4.0, 1.0, True, 0.6251840533636174),
     ],
 )
 def test_Baughman_generalized_wind_reduction_factor_unsheltered_regression(


### PR DESCRIPTION
Add urban canyon vertical interpolation from Masson (2000). 

## Issue
Closes #30

### Reference
Masson, V. (2000). A physically-based scheme for the urban energy budget in atmospheric models.
    Boundary-Layer Meteorology, 94, 357-397.