### PR TITLE
Add California weather station info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] 
 ### Added
 ### Changed
+- Keep the `code-formatting` Makefile target as a Black check and add `fix-code-formatting` to apply Black formatting locally.
 ### Fixed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] 
 ### Added
+- Add verified PG&E station wind sensor-height fallback data to the trusted station resource.
 ### Changed
 - Keep the `code-formatting` Makefile target as a Black check and add `fix-code-formatting` to apply Black formatting locally.
 ### Fixed
+- Support UTC and extended ISO 8601 `date_time` values when standardizing Synoptic observations.
 ### Deprecated
 
 ## [0.9.0] - 2026 / 05 / 18

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Declare these targets as phony to avoid conflicts with files of the same name
-.PHONY: test test-cov lint update-lint-score code-formatting bandit update-docs-changelog check-consistency-namespace generate-api-doc docs clean clean-build install-build-tools build check-dist upload-test upload
+.PHONY: test test-cov lint update-lint-score code-formatting fix-code-formatting bandit update-docs-changelog check-consistency-namespace generate-api-doc docs clean clean-build install-build-tools build check-dist upload-test upload
 
 PYTHON ?= python
 
@@ -19,9 +19,13 @@ lint:
 update-lint-score:
 	python .github/actions/run_pylint.py
 
-# Run black code formatting
+# Check black code formatting
 code-formatting:
 	black --check src/firebench tests .github/actions workflow
+
+# Run black code formatting
+fix-code-formatting:
+	black src/firebench tests .github/actions workflow
 
 # Run bandit analysis
 bandit:

--- a/src/firebench/resources/wx_sensor_height_stations.json
+++ b/src/firebench/resources/wx_sensor_height_stations.json
@@ -1,1 +1,9578 @@
-{}
+{
+    "000PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "001PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "002PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "003PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "004PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "005PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "006PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "007PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "008PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "009PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "010PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "011PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "012PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "013PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "014PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "015PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "016PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "017PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "018PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "019PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "020PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "021PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "022PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "023PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "024PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "025PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "026PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "027PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "028PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "029PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "030PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "032PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "033PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "034PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "035PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "036PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "037PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "038PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "039PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "040PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "041PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "042PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "043PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "044PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "045PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "046PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "047PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "048PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "049PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "050PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "051PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "052PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "053PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "054PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "055PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "056PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "057PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "058PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "059PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "060PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "061PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "062PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "063PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "064PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "065PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "066PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "067PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "068PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "069PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "070PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "071PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "072PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "073PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "074PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "075PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "076PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "077PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "078PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "079PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "080PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "081PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "082PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "083PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.0",
+        "wind_gust_set_1": "4.0",
+        "wind_speed_set_1": "4.0"
+    },
+    "084PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "085PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "086PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "087PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "088PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "089PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "090PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "091PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "093PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "094PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "095PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "096PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "097PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "098PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "099PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "100PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "101PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "102PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "103PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "104PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "105PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "3.7",
+        "wind_gust_set_1": "3.7",
+        "wind_speed_set_1": "3.7"
+    },
+    "108PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "109PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "111PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "112PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "113PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "114PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "115PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "116PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "117PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "118PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "119PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "120PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "121PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "122PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "123PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "124PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "126PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "127PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "128PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "129PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "130PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "131PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "132PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "133PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "134PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "135PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.6",
+        "wind_gust_set_1": "4.6",
+        "wind_speed_set_1": "4.6"
+    },
+    "136PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "137PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "138PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "139PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "140PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "141PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "142PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "143PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "144PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "145PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "146PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "147PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "148PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "149PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "150PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "151PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "152PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "153PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "154PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "155PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "156PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "157PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "158PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "159PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "160PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.3",
+        "wind_gust_set_1": "4.3",
+        "wind_speed_set_1": "4.3"
+    },
+    "161PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "162PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "163PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "164PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "165PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "166PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "167PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "168PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "169PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "170PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "171PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "172PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "173PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.3",
+        "wind_gust_set_1": "4.3",
+        "wind_speed_set_1": "4.3"
+    },
+    "174PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "175PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "176PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "177PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "178PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "179PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "180PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "181PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "182PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "183PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "184PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "185PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "186PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "187PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "188PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "189PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "190PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "191PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "192PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "193PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "194PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "195PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "196PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "197PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "198PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "199PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "200PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "201PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "3.7",
+        "wind_gust_set_1": "3.7",
+        "wind_speed_set_1": "3.7"
+    },
+    "202PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "203PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "204PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.6",
+        "wind_gust_set_1": "6.6",
+        "wind_speed_set_1": "6.6"
+    },
+    "205PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "206PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "207PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "208PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "209PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "210PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "211PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "212PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "213PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "214PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "215PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "216PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "217PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "218PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "219PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "221PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "222PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "223PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "225PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "226PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "227PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "228PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "229PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "230PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "231PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "232PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "233PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "234PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "235PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "236PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "237PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "238PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "239PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "240PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "241PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "242PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "243PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "244PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "245PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "246PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "247PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "248PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "249PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "250PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "251PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "252PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "253PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "254PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "255PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "256PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "257PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "258PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "259PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "260PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "261PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "262PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "263PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "264PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "265PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "266PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "267PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "268PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.3",
+        "wind_gust_set_1": "4.3",
+        "wind_speed_set_1": "4.3"
+    },
+    "269PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "270PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "271PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "273PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "274PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "275PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "276PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "277PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "278PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "279PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "280PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "281PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "282PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "283PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "284PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "285PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "286PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "287PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "288PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "289PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "290PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.0",
+        "wind_gust_set_1": "4.0",
+        "wind_speed_set_1": "4.0"
+    },
+    "291PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "292PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "293PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "294PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "295PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "296PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "297PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "298PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "299PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "300PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "301PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "302PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "303PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "304PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "305PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "306PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "307PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "308PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "309PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "310PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "311PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "312PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "313PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "314PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "315PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "316PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "317PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "318PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "319PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "320PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "321PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "322PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "323PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "324PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "325PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "326PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "327PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "328PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "329PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "330PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "331PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "332PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "333PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "334PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "335PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.4",
+        "wind_gust_set_1": "5.4",
+        "wind_speed_set_1": "5.4"
+    },
+    "336PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "337PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "338PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "339PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "340PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "341PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "342PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "343PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "344PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "345PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "346PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "347PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "348PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "349PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "350PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "352PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "353PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "354PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "355PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.6",
+        "wind_gust_set_1": "11.6",
+        "wind_speed_set_1": "11.6"
+    },
+    "356PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "357PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "358PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "359PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "361PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "362PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "363PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "364PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "365PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "366PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "367PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "368PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "369PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "370PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "371PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "372PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "373PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "374PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "375PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "376PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "377PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "378PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "379PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "380PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "381PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "382PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "383PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "384PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "385PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "386PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "387PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "388PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "389PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "390PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.2",
+        "wind_gust_set_1": "5.2",
+        "wind_speed_set_1": "5.2"
+    },
+    "391PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "392PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "393PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "394PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "395PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "396PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "397PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "398PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "399PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "400PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "401PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "402PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "403PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "404PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "405PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "406PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "407PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "408PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "409PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "410PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "411PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "412PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "413PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "414PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "415PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "416PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "417PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "418PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "419PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "420PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "421PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "422PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "423PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "424PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "425PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "426PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "427PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.0",
+        "wind_gust_set_1": "4.0",
+        "wind_speed_set_1": "4.0"
+    },
+    "428PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "429PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "430PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "431PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "432PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "433PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "434PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "435PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "436PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "437PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "438PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "439PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "440PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "441PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "442PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "443PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.3",
+        "wind_gust_set_1": "6.3",
+        "wind_speed_set_1": "6.3"
+    },
+    "444PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "445PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "446PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "447PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "448PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "449PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "450PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "451PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "452PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "453PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "454PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "455PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "456PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "457PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "458PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "459PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "460PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "461PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "462PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "463PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.0",
+        "wind_gust_set_1": "4.0",
+        "wind_speed_set_1": "4.0"
+    },
+    "464PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "465PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "466PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "467PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "468PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "469PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "470PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "471PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "472PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "473PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "474PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "475PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "476PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "477PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "478PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "479PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "480PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "481PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "482PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "483PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "484PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "485PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "486PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "487PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "488PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "489PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "490PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "491PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "492PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "493PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "494PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "495PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "496PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "497PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "498PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "499PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "500PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "501PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "502PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "503PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "504PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "506PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "507PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "508PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "509PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "510PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "511PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "512PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "513PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "514PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "515PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "516PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "517PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "518PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "519PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "520PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "521PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "522PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "523PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "524PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "525PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "526PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "527PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "528PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "529PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "530PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "531PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "532PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "533PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "534PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "535PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "536PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "537PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "538PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "539PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.6",
+        "wind_gust_set_1": "4.6",
+        "wind_speed_set_1": "4.6"
+    },
+    "540PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "541PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "542PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "543PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "544PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "545PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "546PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "547PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "548PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "549PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "550PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "552PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "553PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "554PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "555PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "557PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "558PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "559PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "560PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "561PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "562PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "563PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "564PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "565PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "566PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "567PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "568PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "569PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "570PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "571PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "573PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "574PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "575PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "576PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "577PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "578PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "579PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "580PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "581PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "582PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "583PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "584PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "585PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "586PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "587PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "588PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "589PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "590PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "591PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "592PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "593PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "594PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "595PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "596PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "599PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "600PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "601PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "604PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "605PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "606PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "608PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "609PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "610PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "611PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "612PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "613PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "614PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "615PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "616PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "617PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "618PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "619PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "620PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "621PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "622PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "623PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "624PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "625PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "628PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "629PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.3",
+        "wind_gust_set_1": "4.3",
+        "wind_speed_set_1": "4.3"
+    },
+    "630PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "632PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "633PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "634PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "635PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "636PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "638PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "639PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "640PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "641PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "642PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "643PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "644PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "646PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "647PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "648PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "649PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "650PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "651PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "652PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "653PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "654PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "655PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.6",
+        "wind_gust_set_1": "4.6",
+        "wind_speed_set_1": "4.6"
+    },
+    "656PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "662PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "664PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "665PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "666PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "668PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "669PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "676PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "677PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "682PG": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG002": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG003": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG004": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG005": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG006": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG007": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG008": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG010": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG011": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG012": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG013": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG015": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG016": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.0",
+        "wind_gust_set_1": "11.0",
+        "wind_speed_set_1": "11.0"
+    },
+    "PG017": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG018": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG019": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG020": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.0",
+        "wind_gust_set_1": "11.0",
+        "wind_speed_set_1": "11.0"
+    },
+    "PG021": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG022": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG023": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG024": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG025": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG026": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG027": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG028": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG029": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG030": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG031": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG032": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG033": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG034": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG035": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG036": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG037": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG038": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG039": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "13.7",
+        "wind_gust_set_1": "13.7",
+        "wind_speed_set_1": "13.7"
+    },
+    "PG040": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG041": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG044": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG045": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG046": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG047": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.3",
+        "wind_gust_set_1": "11.3",
+        "wind_speed_set_1": "11.3"
+    },
+    "PG048": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG050": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG051": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG053": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG055": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG056": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG057": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG058": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG059": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG060": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.3",
+        "wind_gust_set_1": "11.3",
+        "wind_speed_set_1": "11.3"
+    },
+    "PG061": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG062": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.9",
+        "wind_gust_set_1": "11.9",
+        "wind_speed_set_1": "11.9"
+    },
+    "PG063": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG064": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG065": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG066": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG067": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG068": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG069": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG070": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.9",
+        "wind_gust_set_1": "11.9",
+        "wind_speed_set_1": "11.9"
+    },
+    "PG071": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG072": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG073": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG074": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG075": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG076": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG077": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG078": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.4",
+        "wind_gust_set_1": "8.4",
+        "wind_speed_set_1": "8.4"
+    },
+    "PG079": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG080": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG081": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG082": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG083": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG084": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG085": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG086": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG087": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG088": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG089": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG090": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG091": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.3",
+        "wind_gust_set_1": "11.3",
+        "wind_speed_set_1": "11.3"
+    },
+    "PG092": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.0",
+        "wind_gust_set_1": "11.0",
+        "wind_speed_set_1": "11.0"
+    },
+    "PG093": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG094": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG096": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.0",
+        "wind_gust_set_1": "11.0",
+        "wind_speed_set_1": "11.0"
+    },
+    "PG097": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG098": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG099": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG100": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG101": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG102": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG103": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG104": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG105": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG106": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG107": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG109": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG110": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG111": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG112": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG114": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG115": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG117": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG118": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG119": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG120": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG121": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG122": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG123": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG124": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG125": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG126": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG127": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG128": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG129": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG130": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG131": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG132": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG133": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG134": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG135": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG136": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG137": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG138": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG139": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG140": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG141": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG142": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG143": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG144": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG145": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG146": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG147": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG148": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG149": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG151": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.9",
+        "wind_gust_set_1": "11.9",
+        "wind_speed_set_1": "11.9"
+    },
+    "PG152": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG154": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.0",
+        "wind_gust_set_1": "11.0",
+        "wind_speed_set_1": "11.0"
+    },
+    "PG155": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG156": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG157": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG158": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG159": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG160": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG161": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG162": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG163": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG164": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG165": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG166": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG167": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG168": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG169": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG170": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG171": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG172": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG173": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG174": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG175": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG176": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG177": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG178": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG179": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG180": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG181": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG182": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG183": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG184": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG185": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG186": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG187": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG188": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG189": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG190": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG191": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG192": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG193": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG194": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG195": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG196": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG197": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG198": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG199": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG200": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG201": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG202": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG203": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG204": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG205": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG206": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG207": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG208": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG209": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG210": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG211": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG212": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG213": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG214": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG215": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG216": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG217": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG219": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG220": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG221": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG222": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG223": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG224": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "3.7",
+        "wind_gust_set_1": "3.7",
+        "wind_speed_set_1": "3.7"
+    },
+    "PG225": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG226": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG227": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG228": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG229": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG230": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG231": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG232": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG233": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG234": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG235": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG236": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG237": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG239": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG240": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG241": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG242": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG243": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG244": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG245": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG246": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG247": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG248": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG249": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG250": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG251": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG252": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG253": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG254": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG255": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG256": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG257": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG258": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG259": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG260": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG261": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG262": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG263": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.2",
+        "wind_gust_set_1": "7.2",
+        "wind_speed_set_1": "7.2"
+    },
+    "PG264": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG265": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG266": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG268": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG269": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG270": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG271": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG273": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG274": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG275": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG276": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG277": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG278": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG279": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG280": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG281": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG282": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG283": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG284": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG285": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG286": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG287": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG288": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG289": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG290": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG291": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG292": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG293": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG294": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG295": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG296": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG297": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG298": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG299": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG300": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG301": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG302": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG303": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG304": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG305": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG306": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG307": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG308": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG309": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG310": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG311": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG312": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG313": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG314": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG315": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG316": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG317": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG318": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG319": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG320": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG321": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG322": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG323": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG324": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG325": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG326": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG327": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG328": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG329": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG330": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG331": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG332": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG333": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG334": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG335": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG336": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG337": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG338": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG339": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG340": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG341": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG342": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG343": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG344": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG345": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG346": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG347": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG348": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG349": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG350": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG351": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG352": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG353": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG354": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG355": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG356": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG358": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG359": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG360": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG361": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG362": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG363": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "PG364": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG365": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG366": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG367": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG368": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG369": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG370": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG371": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG373": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG374": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG376": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG377": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG379": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG380": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG381": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG382": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG383": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG384": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG385": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG386": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG387": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG389": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG390": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG391": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG392": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG393": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG394": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG395": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG396": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG397": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG399": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG400": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG402": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG403": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG404": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG405": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG406": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG407": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG408": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG409": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG410": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG411": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG412": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG413": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG414": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG415": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG416": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG417": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG418": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.4",
+        "wind_gust_set_1": "8.4",
+        "wind_speed_set_1": "8.4"
+    },
+    "PG419": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG420": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG421": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG422": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG423": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG424": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG425": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG426": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG427": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG428": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG429": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG430": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG431": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG432": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG433": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG434": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG435": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG436": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG437": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG439": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "12.8",
+        "wind_gust_set_1": "12.8",
+        "wind_speed_set_1": "12.8"
+    },
+    "PG441": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.0",
+        "wind_gust_set_1": "4.0",
+        "wind_speed_set_1": "4.0"
+    },
+    "PG442": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG443": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG444": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG445": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG446": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG447": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG448": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG449": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG450": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG451": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG452": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG453": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG454": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG455": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG456": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG457": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG458": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG459": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG460": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG461": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG463": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG464": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG465": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG466": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG467": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG468": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG469": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG470": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG471": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG472": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG473": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG475": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG476": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG477": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG478": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG479": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG480": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG481": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG482": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG483": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG484": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG485": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG486": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG488": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG489": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG490": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG491": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG492": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG493": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG494": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG495": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG496": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG497": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG498": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG499": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG500": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG501": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG502": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG503": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG504": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG505": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG507": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG508": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG509": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG510": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG511": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG512": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG513": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG514": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG515": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG516": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG517": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG518": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG519": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG520": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG521": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG522": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG523": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG524": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG525": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG526": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG527": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG528": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG529": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG530": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG531": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG532": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG533": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG534": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG535": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG536": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG537": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG538": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG539": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG540": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG541": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG542": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG543": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG544": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.3",
+        "wind_gust_set_1": "11.3",
+        "wind_speed_set_1": "11.3"
+    },
+    "PG545": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG546": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG547": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG548": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG549": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG550": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG551": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.6",
+        "wind_gust_set_1": "11.6",
+        "wind_speed_set_1": "11.6"
+    },
+    "PG552": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG553": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG554": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG556": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG557": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG558": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG559": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG560": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG561": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG562": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG563": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG564": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG565": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG566": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG567": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG568": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG569": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG570": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG571": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG572": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG573": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG574": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG575": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG576": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG577": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG578": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG579": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG580": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG581": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG582": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG584": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG585": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG586": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG587": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.2",
+        "wind_gust_set_1": "5.2",
+        "wind_speed_set_1": "5.2"
+    },
+    "PG588": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG589": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG590": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG591": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG592": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG593": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG594": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG595": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG596": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG597": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG599": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG600": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG601": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG602": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG603": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG604": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG605": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG606": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG607": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG608": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG609": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG610": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG611": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG612": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG613": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG614": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG615": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG616": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG617": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG618": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG619": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG620": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG621": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG622": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG623": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG624": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG625": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG626": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG627": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG629": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG630": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG631": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG632": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG633": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG634": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG635": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG636": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG638": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG639": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG640": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG641": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG642": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG643": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG644": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG645": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG646": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG647": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG648": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG649": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG650": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG651": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG652": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG653": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG654": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG655": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG656": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG657": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG658": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG659": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG660": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG661": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG662": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG663": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG664": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG665": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG667": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG668": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG669": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG670": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG671": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG672": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG673": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG674": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG675": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG676": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG677": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG678": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG679": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG680": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG681": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG682": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG683": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG684": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG685": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG686": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG687": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG688": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG689": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG690": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "PG692": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG693": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG694": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG695": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG696": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG697": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG698": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG699": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG700": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG701": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG702": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG703": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG704": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG705": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG706": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG707": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG708": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG709": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG710": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG711": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG712": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG713": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG714": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG715": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG716": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG717": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG718": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG719": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG720": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG721": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG722": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG723": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG724": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG725": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG726": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG727": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG728": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG729": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG730": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG731": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG732": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG733": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG734": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG735": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG736": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG737": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG738": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG739": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG740": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG741": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG742": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG743": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG744": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG745": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG746": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG747": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG748": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG750": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG751": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG752": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG754": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG755": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG756": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG757": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG758": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG759": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG760": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG761": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG762": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG763": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG764": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG765": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG767": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG768": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG769": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG770": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG771": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG772": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG773": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG774": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG775": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG776": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG777": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG778": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG779": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG780": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG781": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG782": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG783": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG784": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG785": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG786": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG787": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG788": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG789": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG790": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG791": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG792": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG793": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG794": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG795": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG796": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG797": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG798": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG799": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG800": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG801": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG802": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG803": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG804": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG805": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG806": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG807": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG808": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG809": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG811": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG812": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG813": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG814": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG815": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG816": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG817": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG818": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG819": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG820": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG821": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG822": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG823": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG824": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.8",
+        "wind_gust_set_1": "9.8",
+        "wind_speed_set_1": "9.8"
+    },
+    "PG825": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG826": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG827": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG828": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG829": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG830": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG831": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG832": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG833": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG834": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG835": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG836": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG837": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG838": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG839": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG840": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG841": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG842": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG843": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG844": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG845": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG846": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG847": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG848": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG849": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG850": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG851": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG852": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG853": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG854": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG855": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG856": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG857": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.4",
+        "wind_gust_set_1": "9.4",
+        "wind_speed_set_1": "9.4"
+    },
+    "PG858": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG859": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG860": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG861": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.2",
+        "wind_gust_set_1": "5.2",
+        "wind_speed_set_1": "5.2"
+    },
+    "PG862": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG863": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG864": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG865": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG866": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG867": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG868": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG869": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG870": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG871": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG872": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG874": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG875": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG876": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG877": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG878": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG879": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG880": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG881": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG882": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG883": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG884": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG885": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG886": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "PG887": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG888": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG889": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG890": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG891": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG892": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG893": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.1",
+        "wind_gust_set_1": "10.1",
+        "wind_speed_set_1": "10.1"
+    },
+    "PG894": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG895": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG896": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG897": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG898": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG899": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG900": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG901": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG902": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG903": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG904": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG905": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG906": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG907": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG908": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG909": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG910": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.4",
+        "wind_gust_set_1": "10.4",
+        "wind_speed_set_1": "10.4"
+    },
+    "PG911": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG912": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG913": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG914": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG915": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG916": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG917": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG918": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG919": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG920": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG921": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG922": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG923": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG924": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG925": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG926": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG927": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG928": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG929": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG930": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG931": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG932": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG933": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG934": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG935": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.5",
+        "wind_gust_set_1": "8.5",
+        "wind_speed_set_1": "8.5"
+    },
+    "PG936": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG937": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "PG938": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG939": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG940": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG941": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG942": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG943": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG944": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG945": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG946": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "4.9",
+        "wind_gust_set_1": "4.9",
+        "wind_speed_set_1": "4.9"
+    },
+    "PG947": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG948": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG949": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG950": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.5",
+        "wind_gust_set_1": "5.5",
+        "wind_speed_set_1": "5.5"
+    },
+    "PG951": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG952": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG953": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG954": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "10.7",
+        "wind_gust_set_1": "10.7",
+        "wind_speed_set_1": "10.7"
+    },
+    "PG955": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG956": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG957": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG958": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG959": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG960": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG961": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG962": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG963": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.9",
+        "wind_gust_set_1": "6.9",
+        "wind_speed_set_1": "6.9"
+    },
+    "PG964": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "11.6",
+        "wind_gust_set_1": "11.6",
+        "wind_speed_set_1": "11.6"
+    },
+    "PG965": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG966": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG967": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG968": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG969": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG970": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.8",
+        "wind_gust_set_1": "8.8",
+        "wind_speed_set_1": "8.8"
+    },
+    "PG971": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG972": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG973": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "9.1",
+        "wind_gust_set_1": "9.1",
+        "wind_speed_set_1": "9.1"
+    },
+    "PG974": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG975": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG976": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.7",
+        "wind_gust_set_1": "6.7",
+        "wind_speed_set_1": "6.7"
+    },
+    "PG977": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG978": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG979": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG980": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG981": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG982": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG983": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG984": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG986": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "5.8",
+        "wind_gust_set_1": "5.8",
+        "wind_speed_set_1": "5.8"
+    },
+    "PG987": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.3",
+        "wind_gust_set_1": "7.3",
+        "wind_speed_set_1": "7.3"
+    },
+    "PG988": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG989": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG990": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG991": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG992": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG993": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    },
+    "PG994": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.1",
+        "wind_gust_set_1": "6.1",
+        "wind_speed_set_1": "6.1"
+    },
+    "PG995": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.0",
+        "wind_gust_set_1": "7.0",
+        "wind_speed_set_1": "7.0"
+    },
+    "PG996": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.6",
+        "wind_gust_set_1": "7.6",
+        "wind_speed_set_1": "7.6"
+    },
+    "PG997": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "8.2",
+        "wind_gust_set_1": "8.2",
+        "wind_speed_set_1": "8.2"
+    },
+    "PG998": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "7.9",
+        "wind_gust_set_1": "7.9",
+        "wind_speed_set_1": "7.9"
+    },
+    "PG999": {
+        "provider": "Western Weather Group",
+        "wind_direction_set_1": "6.4",
+        "wind_gust_set_1": "6.4",
+        "wind_speed_set_1": "6.4"
+    }
+}

--- a/src/firebench/standardize/synoptic.py
+++ b/src/firebench/standardize/synoptic.py
@@ -115,12 +115,12 @@ def standardize_synoptic_raws_from_json(
                 dts = []
 
                 for t in station_dict["OBSERVATIONS"]["date_time"]:
-                    # differntiates between YYYYMMDDHHMMSS or extended ISO 8601
-                    if t.endswith("Z"): # Detects if format in UTC timezone
+                    # differentiates between YYYYMMDDHHMMSS or extended ISO 8601
+                    if t.endswith("Z"):  # Detects if format in UTC timezone
                         fmt = "%Y%m%d%H%M%SZ" if t[:-1].isdigit() else "%Y-%m-%dT%H:%M:%SZ"
                         dt_temp = pytz.utc.localize(datetime.strptime(t, fmt)).astimezone(tz)
 
-                    else: # Assumes local timezone
+                    else:  # Assumes local timezone
                         fmt = "%Y%m%d%H%M%S" if t.isdigit() else "%Y-%m-%dT%H:%M:%S"
                         dt_temp = tz.localize(datetime.strptime(t, fmt))
 

--- a/src/firebench/standardize/synoptic.py
+++ b/src/firebench/standardize/synoptic.py
@@ -112,10 +112,20 @@ def standardize_synoptic_raws_from_json(
         for var in station_dict["OBSERVATIONS"]:
             if var == "date_time":
                 tz = pytz.timezone(station_dict["TIMEZONE"])
-                dts = [
-                    tz.localize(datetime.strptime(t, "%Y%m%d%H%M%S"))
-                    for t in station_dict["OBSERVATIONS"]["date_time"]
-                ]
+                dts = []
+
+                for t in station_dict["OBSERVATIONS"]["date_time"]:
+                    # differntiates between YYYYMMDDHHMMSS or extended ISO 8601
+                    if t.endswith("Z"): # Detects if format in UTC timezone
+                        fmt = "%Y%m%d%H%M%SZ" if t[:-1].isdigit() else "%Y-%m-%dT%H:%M:%SZ"
+                        dt_temp = pytz.utc.localize(datetime.strptime(t, fmt)).astimezone(tz)
+
+                    else: # Assumes local timezone
+                        fmt = "%Y%m%d%H%M%S" if t.isdigit() else "%Y-%m-%dT%H:%M:%S"
+                        dt_temp = tz.localize(datetime.strptime(t, fmt))
+
+                    dts.append(dt_temp)
+
                 dt0 = dts[0]
                 first_time_iso = datetime_to_iso8601(dt0, True)
                 rel_minutes = [(dt - dt0).total_seconds() / 60.0 for dt in dts]


### PR DESCRIPTION
### Added
- Add verified PG&E station wind sensor-height fallback data to the trusted station resource.
### Changed
- Keep the `code-formatting` Makefile target as a Black check and add `fix-code-formatting` to apply Black formatting locally.
### Fixed
- Support UTC and extended ISO 8601 `date_time` values when standardizing Synoptic observations.